### PR TITLE
* The project measures how often (or rather rarely) does a thread get…

### DIFF
--- a/2017/C#/ThreadTimeQuant/ThreadTimeQuant.sln
+++ b/2017/C#/ThreadTimeQuant/ThreadTimeQuant.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThreadTimeQuant", "ThreadTimeQuant\ThreadTimeQuant.csproj", "{EFD032D6-8E77-4E56-8786-19F84C60AF24}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EFD032D6-8E77-4E56-8786-19F84C60AF24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFD032D6-8E77-4E56-8786-19F84C60AF24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFD032D6-8E77-4E56-8786-19F84C60AF24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFD032D6-8E77-4E56-8786-19F84C60AF24}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/2017/C#/ThreadTimeQuant/ThreadTimeQuant/App.config
+++ b/2017/C#/ThreadTimeQuant/ThreadTimeQuant/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/2017/C#/ThreadTimeQuant/ThreadTimeQuant/Program.cs
+++ b/2017/C#/ThreadTimeQuant/ThreadTimeQuant/Program.cs
@@ -1,0 +1,10 @@
+﻿namespace ThreadTimeQuant
+{
+    internal class Program
+    {
+        private static void Main()
+        {
+            new ThreadsSample().Run();
+        }
+    }
+}

--- a/2017/C#/ThreadTimeQuant/ThreadTimeQuant/Properties/AssemblyInfo.cs
+++ b/2017/C#/ThreadTimeQuant/ThreadTimeQuant/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ThreadTimeQuant")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ThreadTimeQuant")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("efd032d6-8e77-4e56-8786-19f84c60af24")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/2017/C#/ThreadTimeQuant/ThreadTimeQuant/ThreadTimeQuant.csproj
+++ b/2017/C#/ThreadTimeQuant/ThreadTimeQuant/ThreadTimeQuant.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EFD032D6-8E77-4E56-8786-19F84C60AF24}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ThreadTimeQuant</RootNamespace>
+    <AssemblyName>ThreadTimeQuant</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ThreadsSample.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/2017/C#/ThreadTimeQuant/ThreadTimeQuant/ThreadsSample.cs
+++ b/2017/C#/ThreadTimeQuant/ThreadTimeQuant/ThreadsSample.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace ThreadTimeQuant
+{
+    internal class ThreadsSample
+    {
+        private const int ThreadsCount = 5;
+        private const double TimeQuantLimit = 50;
+
+        public void Run()
+        {
+            IEnumerable<Thread> threads = 
+                Enumerable
+                    .Range(0, ThreadsCount)
+                    .Select(i => new Thread(ThreadBody)
+                    {
+                        IsBackground = true,
+                        Name = $"Thread {(char)('A' + i)}"
+                    });
+
+            foreach (Thread thread in threads) { thread.Start(); }
+
+            Console.ReadKey();
+        }
+
+        public void ThreadBody()
+        {
+            DateTime prevDate = DateTime.Now;
+            for (;;)
+            {
+                DateTime newDate = DateTime.Now;
+                TimeSpan timeDiff = newDate - prevDate;
+
+                if (timeDiff.TotalMilliseconds > TimeQuantLimit)
+                {
+                    Console.WriteLine($"{Thread.CurrentThread.Name} didn't get the time quant for more than {TimeQuantLimit} mls. Actual waiting time: {timeDiff.TotalMilliseconds} mls.");
+                }
+
+                prevDate = newDate;
+            }
+            // ReSharper disable once FunctionNeverReturns
+        }
+    }
+}


### PR DESCRIPTION
** The project measures how often (or rather rarely) does a thread get the CPU time depending on the amount of the CPU cores and the amount of run threads
** For the 4 non-HT core machine and five 100% loading threads (e.g. for (;;) doSomething();) it showed that some of the thread doesn't get any quant for longer than 50 mls
** For 8 running threads on the same machine the time gap increases to hundreds of mls
** For 16 threads it is already seconds!
* This sample confirmed the assumption that OS is able to switch threads at max 60 times per second.
* Which means we can't get any visible continuous\smooth execution in case if an amount of 100% loading threads is bigger than an amount of non hyper-threading cores.
